### PR TITLE
Update action to introduce new input variable 'rm_top_dir'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+This is a fork of andstor/copycat-action. It extends the action to remove the src_path from the dst_path. This is useful when copying files from a subfolder to the root of the destination repo.
 <p align=center>
 	<img width="240" src="media/logo.svg" alt="Copycat Logo">
 </p>
@@ -15,7 +16,7 @@ The following example [workflow step](https://help.github.com/en/actions/configu
 
 ```yml
 - name: Copy
-  uses: andstor/copycat-action@v3
+  uses: mulliongroup/copycat-action@v1.0.0
   with:
     personal_token: ${{ secrets.PERSONAL_TOKEN }}
     src_path: /.
@@ -80,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Copycat
-      uses: andstor/copycat-action@v3
+      uses: mulliongroup/copycat-action@v3
       with:
         personal_token: ${{ secrets.PERSONAL_TOKEN }}
         src_path: /.
@@ -104,17 +105,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Copycat
-      uses: andstor/copycat-action@v3
+      uses: mulliongroup/copycat-action@v1.0.0
       with:
         personal_token: ${{ secrets.PERSONAL_TOKEN }}
-        src_path: /dbclient/
-        dst_path: /dbclient_sm/
+        src_path: /service/
+        dst_path: /monoservice/
         dst_owner: MullionGroup
-        dst_repo_name: flintpro-be
+        dst_repo_name: test-repo
         dst_branch: develop
         src_branch: sync-develop
-        username: DevOpsBot
-        email: dev_ops_bot@flintpro.com
+        username: TestUser
+        email: TestUser@example.com
 ```
 will copy all files from the dbclient folder to the dbclient_sm folder in the flintpro-be repo with the pattern /dbclient_sm/dbclient/*
 
@@ -127,18 +128,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Copycat
-      uses: andstor/copycat-action@v3
+      uses: mulliongroup/copycat-action@v1.0.0
       with:
         personal_token: ${{ secrets.PERSONAL_TOKEN }}
-        src_path: /dbclient/
-        dst_path: /dbclient_sm/
+        src_path: /service/
+        dst_path: /monoservice/
         dst_owner: MullionGroup
-        dst_repo_name: flintpro-be
+        dst_repo_name: test-repo
         dst_branch: develop
         src_branch: sync-develop
-        username: DevOpsBot
-        email: dev_ops_bot@flintpro.com
-        rm_top_dir: true
+        username: TestUser
+        email: TestUser@example.com
 ```
 will copy all files from the dbclient folder to the dbclient_sm folder in the flintpro-be repo with the pattern /dbclient_sm/* 
 

--- a/README.md
+++ b/README.md
@@ -28,23 +28,24 @@ The following example [workflow step](https://help.github.com/en/actions/configu
 
 The following input variable options can/must be configured:
 
-|Input variable|Necessity|Description|Default|
-|--------------------|--------|-----------|-------|
-|`src_path`|Required|The source path to the file(s) or folder(s) to copy from. For example `/.` or `path/to/home.md`.||
-|`dst_path`|Optional|The destination path to copy the file(s) or folder(s) to. For example `/wiki/` or `path/to/index.md`. |`src_path`|
-|`dst_owner`|Required|The name of the owner of the repository to push to. For example `andstor`.||
-|`dst_repo_name`|Required|The name of the repository to push to. For example `copycat-action`.||
-|`src_branch`|Optional|The name of the branch in source repository to clone from.|`master`|
-|`dst_branch`|Optional|The name of the branch in the destination repository to push to. If the branch doesn't exists, the branch will be created based on the default branch.|`master`|
-|`clean`|Optional|Set to `true` if the `dst_path` should be emptied before copying.|`false`|
-|`file_filter`|Optional|A simple [pattern](https://www.gnu.org/software/findutils/manual/html_mono/find.html#Shell-Pattern-Matching) for filtering files to be copied. Acts on file basename. For example `*.sh`.||
-|`filter`|Optional|A glob pattern for filtering files to be copied. Acts on file paths. For example `**/!(*.*)`.||
-|`exclude`|Optional|A glob pattern for excluding paths. For example `*/tests/*`.||
-|`src_wiki`|Optional|Set to `true` if the source repository you want to copy from is the GitHub Wiki.| `false`|
-|`dst_wiki`|Optional|Set to `true` if the destination repository you want to copy from is the GitHub Wiki.|`false`|
-|`commit_message`|Optional|A custom git commit message.||
-|`username`|Optional|The GitHub username to associate commits made by this GitHub action.|[`GITHUB_ACTOR`](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables)|
-|`email`|Optional|The email used for associating commits made by this GitHub action.|[`GITHUB_ACTOR`](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables) `@users.noreply.github.com`|
+|Input variable|Necessity| Description                                                                                                                                                                                                                                |Default|
+|--------------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|
+|`src_path`|Required| The source path to the file(s) or folder(s) to copy from. For example `/.` or `path/to/home.md`.                                                                                                                                           ||
+|`dst_path`|Optional| The destination path to copy the file(s) or folder(s) to. For example `/wiki/` or `path/to/index.md`.                                                                                                                                      |`src_path`|
+|`dst_owner`|Required| The name of the owner of the repository to push to. For example `andstor`.                                                                                                                                                                 ||
+|`dst_repo_name`|Required| The name of the repository to push to. For example `copycat-action`.                                                                                                                                                                       ||
+|`src_branch`|Optional| The name of the branch in source repository to clone from.                                                                                                                                                                                 |`master`|
+|`dst_branch`|Optional| The name of the branch in the destination repository to push to. If the branch doesn't exists, the branch will be created based on the default branch.                                                                                     |`master`|
+|`clean`|Optional| Set to `true` if the `dst_path` should be emptied before copying.                                                                                                                                                                          |`false`|
+|`file_filter`|Optional| A simple [pattern](https://www.gnu.org/software/findutils/manual/html_mono/find.html#Shell-Pattern-Matching) for filtering files to be copied. Acts on file basename. For example `*.sh`.                                                  ||
+|`filter`|Optional| A glob pattern for filtering files to be copied. Acts on file paths. For example `**/!(*.*)`.                                                                                                                                              ||
+|`exclude`|Optional| A glob pattern for excluding paths. For example `*/tests/*`.                                                                                                                                                                               ||
+|`src_wiki`|Optional| Set to `true` if the source repository you want to copy from is the GitHub Wiki.                                                                                                                                                           | `false`|
+|`dst_wiki`|Optional| Set to `true` if the destination repository you want to copy from is the GitHub Wiki.                                                                                                                                                      |`false`|
+|`commit_message`|Optional| A custom git commit message.                                                                                                                                                                                                               ||
+|`username`|Optional| The GitHub username to associate commits made by this GitHub action.                                                                                                                                                                       |[`GITHUB_ACTOR`](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables)|
+|`email`|Optional| The email used for associating commits made by this GitHub action.                                                                                                                                                                         |[`GITHUB_ACTOR`](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables) `@users.noreply.github.com`|
+|`rm_top_dir`|Optional| Set to `true` if the top directory of the source path should be removed. For example, if `src_path` is `/foo/bar/` and `rm_top_dir` is `true`, the files will be copied to `/bar/` in the destination path for the destination repository. |`false`|
 
 ## Secrets
 
@@ -71,7 +72,6 @@ The `exclude` input variable can be used to exclude certain paths. It will apply
 This workflow configuration will copy all files from the repository's wiki to a folder named `wiki` in the destination repo `andstor.github.io`.
 
 This can for example be used to merge several wikies of an organisation, and display them on a custom GitHub Pages site. The Jekyll theme [Paper](https://github.com/andstor/jekyll-theme-paper) has support for this.
-
 ```yml
 name: Copy
 on: gollum
@@ -94,6 +94,53 @@ jobs:
         username: nutsbot
         email: andr3.storhaug+bot@gmail.com
 ```
+
+### Copy files to external repo 
+```yml
+name: Copy
+on: gollum
+jobs:
+  copy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Copycat
+      uses: andstor/copycat-action@v3
+      with:
+        personal_token: ${{ secrets.PERSONAL_TOKEN }}
+        src_path: /dbclient/
+        dst_path: /dbclient_sm/
+        dst_owner: MullionGroup
+        dst_repo_name: flintpro-be
+        dst_branch: develop
+        src_branch: sync-develop
+        username: DevOpsBot
+        email: dev_ops_bot@flintpro.com
+```
+will copy all files from the dbclient folder to the dbclient_sm folder in the flintpro-be repo with the pattern /dbclient_sm/dbclient/*
+
+
+```yml
+name: Copy-to-dst-path
+on: gollum
+jobs:
+  copy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Copycat
+      uses: andstor/copycat-action@v3
+      with:
+        personal_token: ${{ secrets.PERSONAL_TOKEN }}
+        src_path: /dbclient/
+        dst_path: /dbclient_sm/
+        dst_owner: MullionGroup
+        dst_repo_name: flintpro-be
+        dst_branch: develop
+        src_branch: sync-develop
+        username: DevOpsBot
+        email: dev_ops_bot@flintpro.com
+        rm_top_dir: true
+```
+will copy all files from the dbclient folder to the dbclient_sm folder in the flintpro-be repo with the pattern /dbclient_sm/* 
 
 ## Author
 

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ inputs:
     description: 'The email used for associating commits made by this GitHub action'
     required: false
   rm_top_dir:
-    description: 'Set to true if the top directory should be removed from the destination path'
+    description: 'Set to true if the top directory should be removed from the destination path after file(s) or folder(s) have been copied to the destination repository'
     required: false
     default: false
 runs:

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,10 @@ inputs:
   email:
     description: 'The email used for associating commits made by this GitHub action'
     required: false
+  rm_top_dir:
+    description: 'Set to true if the top directory should be removed from the destination path'
+    required: false
+    default: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -78,3 +82,4 @@ runs:
     - ${{ inputs.commit_message }}
     - ${{ inputs.username }}
     - ${{ inputs.email }}
+    - ${{ inputs.rm_top_dir }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,7 @@ DST_WIKI="$INPUT_DST_WIKI"
 COMMIT_MESSAGE="$INPUT_COMMIT_MESSAGE"
 USERNAME="$INPUT_USERNAME"
 EMAIL="$INPUT_EMAIL"
+RM_TOP_DIR="$INPUT_RM_TOP_DIR"
 
 if [[ -z "$SRC_PATH" ]]; then
     echo "SRC_PATH environment variable is missing. Cannot proceed."
@@ -141,8 +142,33 @@ if [ "$CLEAN" = "true" ]; then
 fi
 
 mkdir -p "${DST_REPO_DIR}/${DST_PATH%/*}" || exit "$?"
+
+
+
+
 cp -rf "${FINAL_SOURCE}" "${DST_REPO_DIR}/${DST_PATH}" || exit "$?"
+
+
+
 cd "${DST_REPO_DIR}" || exit "$?"
+
+# if remove src_dir_from_dst_path is true, remove the source directory from the destination path
+# if rm_top_dir is true, remove the top directory from the destination path by copying the contents of 
+if [ "$RM_TOP_DIR" = "true" ]; then
+    # cd to the DST_PATH directory
+    cd "${DST_PATH%/*}" || exit "$?"
+
+    if [ -d "${SRC_PATH}" ] ; then
+        # recursively copy the contents of the source path to the current directory and rm the source directory. Exit with code 1 if the copy fails
+        cp -rf "${SRC_PATH}"/* . && rm -rf "${SRC_PATH}" || exit "$?"
+        
+    else
+        # exit with error and error message
+        echo >&2 "Source directory does not exist"
+        exit 1
+    fi
+fi
+
 
 if [[ -z "${COMMIT_MESSAGE}" ]]; then
     if [ -f "${BASE_PATH}/${FINAL_SOURCE}" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -152,8 +152,7 @@ cp -rf "${FINAL_SOURCE}" "${DST_REPO_DIR}/${DST_PATH}" || exit "$?"
 
 cd "${DST_REPO_DIR}" || exit "$?"
 
-# if remove src_dir_from_dst_path is true, remove the source directory from the destination path
-# if rm_top_dir is true, remove the top directory from the destination path by copying the contents of 
+# if rm_top_dir is true, remove the top directory(s) from the destination path by copying the contents of 
 if [ "$RM_TOP_DIR" = "true" ]; then
     # cd to the DST_PATH directory
     cd "${DST_PATH%/*}" || exit "$?"


### PR DESCRIPTION
POC test to change shape of the final destination path. 

Example: 

Prior to changes using `SRC_PATH=service_a/service/` `DST_PATH=service_b/` would result in dst_path path being set to /service_b/service_a/service/ so if you had  `service_a/service/handlers.go` it would be appended as `service_b/service_a/service/handlers.go` 

Using the RM_TOP_DIR input variable means that the new dst path would for the handlers.go file would be `service_b/service/handlers.go`