### PR TITLE
Add force push Input Variable 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,10 @@ inputs:
     description: 'Set to true if the top directory should be removed from the destination path after file(s) or folder(s) have been copied to the destination repository'
     required: false
     default: false
+  force_push:
+    description: 'Set to true if the destination repository should be force pushed to. Useful if multiple GitHub jobs in a github action are copying files to the same destination repository.'
+    required: false
+    default: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -83,3 +87,4 @@ runs:
     - ${{ inputs.username }}
     - ${{ inputs.email }}
     - ${{ inputs.rm_top_dir }}
+    - ${{ inputs.force_push }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,7 @@ COMMIT_MESSAGE="$INPUT_COMMIT_MESSAGE"
 USERNAME="$INPUT_USERNAME"
 EMAIL="$INPUT_EMAIL"
 RM_TOP_DIR="$INPUT_RM_TOP_DIR"
+FORCE_PUSH="$INPUT_FORCE_PUSH"
 
 if [[ -z "$SRC_PATH" ]]; then
     echo "SRC_PATH environment variable is missing. Cannot proceed."
@@ -191,7 +192,13 @@ else
     # Uncommitted changes
     git add -A
     git commit --message "${COMMIT_MESSAGE}"
-    git push origin ${DST_BRANCH}
+    
+    # if force push is true, force push to the destination branch
+    if [ "$FORCE_PUSH" = "true" ]; then
+        git push --force origin ${DST_BRANCH}
+    else
+        git push origin ${DST_BRANCH}
+    fi
 fi
 
 echo "Copying complete 👌"


### PR DESCRIPTION
Add force push input variable to handle fast-forward race conditions. Useful …when multiple jobs are defined in the same workflow file that push to the same repo
